### PR TITLE
Integrate Dart Coverage Package for Test Coverage Collection

### DIFF
--- a/bin/testgen.dart
+++ b/bin/testgen.dart
@@ -2,7 +2,7 @@ import 'dart:io';
 
 import 'package:args/args.dart';
 import 'package:path/path.dart' as path;
-import 'package:testgen/src/coverage/coverage_integration.dart';
+import 'package:testgen/src/coverage/coverage_collection.dart';
 import 'package:testgen/src/coverage/util.dart';
 
 ArgParser _createArgParser() =>
@@ -54,7 +54,7 @@ class Flags {
   final String vmServicePort;
   final bool branchCoverage;
   final bool functionCoverage;
-  final List<String> scopeOutput;
+  final Set<String> scopeOutput;
 }
 
 Future<Flags> parseArgs(List<String> arguments) async {
@@ -98,26 +98,24 @@ ${parser.usage}
   final scopes =
       results['scope-output'].isEmpty
           ? getAllWorkspaceNames(packageDir)
-          : results['scope-output'];
+          : results['scope-output'] as List<String>;
 
   return Flags(
     package: packageDir,
     vmServicePort: results['port'],
     branchCoverage: results['branch-coverage'],
     functionCoverage: results['function-coverage'],
-    scopeOutput: scopes,
+    scopeOutput: scopes.toSet(),
   );
 }
 
 Future<void> main(List<String> arguments) async {
   final flags = await parseArgs(arguments);
-  final coverage = await runTestsAndCollectCoverage(
+  await runTestsAndCollectCoverage(
     flags.package,
-    flags.vmServicePort,
-    flags.branchCoverage,
-    flags.functionCoverage,
-    flags.scopeOutput.toSet(),
+    vmServicePort: flags.vmServicePort,
+    branchCoverage: flags.branchCoverage,
+    functionCoverage: flags.functionCoverage,
+    scopeOutput: flags.scopeOutput,
   );
-  print("Coverage Collected:");
-  print('Total lines: ${coverage.values}');
 }

--- a/bin/testgen.dart
+++ b/bin/testgen.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:args/args.dart';
 import 'package:path/path.dart' as path;
+import 'package:testgen/src/coverage/coverage_integration.dart';
 import 'package:testgen/src/coverage/util.dart';
 
 ArgParser _createArgParser() =>
@@ -109,5 +110,14 @@ ${parser.usage}
 }
 
 Future<void> main(List<String> arguments) async {
-  await parseArgs(arguments);
+  final flags = await parseArgs(arguments);
+  final coverage = await runTestsAndCollectCoverage(
+    flags.package,
+    flags.vmServicePort,
+    flags.branchCoverage,
+    flags.functionCoverage,
+    flags.scopeOutput.toSet(),
+  );
+  print("Coverage Collected:");
+  print('Total lines: ${coverage.values}');
 }

--- a/bin/testgen.dart
+++ b/bin/testgen.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:google_generative_ai/google_generative_ai.dart';
+import 'package:testgen/src/coverage/coverage_integration.dart';
 import 'package:testgen/src/file_manager.dart';
 import 'package:testgen/src/llm.dart';
 import 'package:testgen/src/utils.dart';
@@ -47,23 +48,31 @@ Future<void> main(List<String> arguments) async {
   }
 
   final rootDirectory = arguments[0];
-  final filePaths = exploreDartFiles(rootDirectory);
-
-  final model = createModel();
-  filePaths.removeAt(0); // Remove the export file of the package from the list.
-
-  for (final filePath in filePaths) {
-    final fileContent = readFromFile(filePath);
-    final fileRelativePath = getRootDirectoryRelativePath(filePath);
-
-    print('Generating Test file... for \'$fileRelativePath\'');
-
-    final isTestFileGenerated = await processFile(filePath, fileContent, model);
-
-    if (isTestFileGenerated) {
-      print('✅ Test file generated successfully for $fileRelativePath');
-    } else {
-      print('❌ Test file not generated successfully');
-    }
+  // call test and retreive coverage from the root directory specified
+  if (!Directory(rootDirectory).existsSync()) {
+    stderr.writeln('The provided directory does not exist: $rootDirectory');
+    exit(1);
   }
+  print('Generating tests for Dart files in: $rootDirectory');
+  final testCoverage = await getTestCoverage(rootDirectory);
+  
+  // final filePaths = exploreDartFiles(rootDirectory);
+
+  // final model = createModel();
+  // filePaths.removeAt(0); // Remove the export file of the package from the list.
+
+  // for (final filePath in filePaths) {
+  //   final fileContent = readFromFile(filePath);
+  //   final fileRelativePath = getRootDirectoryRelativePath(filePath);
+
+  //   print('Generating Test file... for \'$fileRelativePath\'');
+
+  //   final isTestFileGenerated = await processFile(filePath, fileContent, model);
+
+  //   if (isTestFileGenerated) {
+  //     print('✅ Test file generated successfully for $fileRelativePath');
+  //   } else {
+  //     print('❌ Test file not generated successfully');
+  //   }
+  // }
 }

--- a/lib/src/coverage/coverage_integration.dart
+++ b/lib/src/coverage/coverage_integration.dart
@@ -1,98 +1,24 @@
 import 'dart:async';
-import 'dart:convert' show json, LineSplitter;
 import 'dart:io';
 
 import 'package:coverage/coverage.dart';
 import 'package:stack_trace/stack_trace.dart';
+import 'package:testgen/src/coverage/util.dart';
+
+typedef CoverageData = Map<String, dynamic>;
 
 final _allProcesses = <Process>[];
 
-void _killSubprocessesAndExit(ProcessSignal signal) {
-  for (final process in _allProcesses) {
-    process.kill(signal);
-  }
-  exit(1);
-}
-
-void _watchExitSignal(ProcessSignal signal) {
-  signal.watch().listen(_killSubprocessesAndExit);
-}
-
-Future<Map<String, dynamic>> getTestCoverage(String packagRootDirectory) async {
-  _watchExitSignal(ProcessSignal.sighup);
-  _watchExitSignal(ProcessSignal.sigint);
-  if (!Platform.isWindows) {
-    _watchExitSignal(ProcessSignal.sigterm);
-  }
-
-  final serviceUriCompleter = Completer<Uri>();
-
-  final testProcess = _dartRun(
-    [
-      'run',
-      '--pause-isolates-on-exit',
-      '--disable-service-auth-codes',
-      '--enable-vm-service=0',
-      'test',
-    ],
-    onStdout: (line) {
-      if (!serviceUriCompleter.isCompleted) {
-        final uri = _extractVMServiceUri(line);
-        if (uri != null) {
-          serviceUriCompleter.complete(uri);
-        }
-      }
-    },
-    onStderr: (line) {
-      if (!serviceUriCompleter.isCompleted) {
-        if (line.contains('Could not start the VM service')) {
-          _killSubprocessesAndExit(ProcessSignal.sigkill);
-        }
-      }
-    },
-    workingDirectory: packagRootDirectory,
-  );
-
-  final serviceUri = await serviceUriCompleter.future;
-
-  // TODO: need to extract the scope output from the pubsec.yaml file
-  final Set<String> scopes = {};
-  Map<String, dynamic>? coverage;
-  await Chain.capture(
-    () async {
-      print("Collecting coverage from $packagRootDirectory");
-      coverage = await collect(
-        serviceUri,
-        true,
-        true,
-        false,
-        scopes,
-        functionCoverage: true,
-      );
-      print(json.encode(coverage));
-    },
-    onError: (dynamic error, Chain chain) {
-      stderr.writeln(error);
-      stderr.writeln(chain.terse);
-      // See http://www.retro11.de/ouxr/211bsd/usr/include/sysexits.h.html
-      // EX_SOFTWARE
-      exit(70);
-    },
-  );
-  await testProcess;
-  return coverage!;
-}
-
 Future<void> _dartRun(
-  List<String> args, {
+  List<String> args,
+  String packageDir, {
   required void Function(String) onStdout,
   required void Function(String) onStderr,
-  required String workingDirectory,
 }) async {
   final process = await Process.start(
     Platform.executable,
     args,
-    workingDirectory: workingDirectory,
+    workingDirectory: packageDir,
   );
   _allProcesses.add(process);
 
@@ -115,18 +41,84 @@ Future<void> _dartRun(
   }
 }
 
-Uri? _extractVMServiceUri(String str) {
-  final listeningMessageRegExp = RegExp(
-    r'(?:Observatory|The Dart VM service is) listening on ((http|//)[a-zA-Z0-9:/=_\-\.\[\]]+)',
-  );
-  final match = listeningMessageRegExp.firstMatch(str);
-  if (match != null) {
-    return Uri.parse(match[1]!);
+void _killSubprocessesAndExit(ProcessSignal signal) {
+  for (final process in _allProcesses) {
+    process.kill(signal);
   }
-  return null;
+  exit(1);
 }
 
-extension StandardOutExtension on Stream<List<int>> {
-  Stream<String> lines() =>
-      transform(const SystemEncoding().decoder).transform(const LineSplitter());
+void _watchExitSignal(ProcessSignal signal) {
+  signal.watch().listen(_killSubprocessesAndExit);
+}
+
+Future<CoverageData> runTestsAndCollectCoverage(
+  String packageDir,
+  String vmServicePort,
+  bool branchCoverage,
+  bool functionCoverage,
+  Set<String> scopeOutput,
+) async {
+  _watchExitSignal(ProcessSignal.sighup);
+  _watchExitSignal(ProcessSignal.sigint);
+  if (!Platform.isWindows) {
+    _watchExitSignal(ProcessSignal.sigterm);
+  }
+
+  final serviceUriCompleter = Completer<Uri>();
+  final testProcess = _dartRun(
+    [
+      if (branchCoverage) '--branch-coverage',
+      'run',
+      '--pause-isolates-on-exit',
+      '--disable-service-auth-codes',
+      '--enable-vm-service=$vmServicePort',
+      'test',
+    ],
+    packageDir,
+    onStdout: (line) {
+      if (!serviceUriCompleter.isCompleted) {
+        final uri = extractVMServiceUri(line);
+        if (uri != null) {
+          serviceUriCompleter.complete(uri);
+        }
+      }
+    },
+    onStderr: (line) {
+      if (!serviceUriCompleter.isCompleted) {
+        if (line.contains('Could not start the VM service')) {
+          _killSubprocessesAndExit(ProcessSignal.sigkill);
+        }
+      }
+    },
+  );
+
+  final serviceUri = await serviceUriCompleter.future;
+
+  CoverageData coverage = {};
+  await Chain.capture(
+    () async {
+      print("Collecting coverage from $packageDir");
+      coverage = await collect(
+        serviceUri,
+        true,
+        true,
+        false,
+        scopeOutput,
+        branchCoverage: branchCoverage,
+        functionCoverage: functionCoverage,
+      );
+    },
+    onError: (dynamic error, Chain chain) {
+      stderr.writeln(error);
+      stderr.writeln(chain.terse);
+      // See http://www.retro11.de/ouxr/211bsd/usr/include/sysexits.h.html
+      // EX_SOFTWARE
+      exit(70);
+    },
+  );
+
+  await testProcess;
+
+  return coverage;
 }

--- a/lib/src/coverage/coverage_integration.dart
+++ b/lib/src/coverage/coverage_integration.dart
@@ -1,0 +1,132 @@
+import 'dart:async';
+import 'dart:convert' show json, LineSplitter;
+import 'dart:io';
+
+import 'package:coverage/coverage.dart';
+import 'package:stack_trace/stack_trace.dart';
+
+final _allProcesses = <Process>[];
+
+void _killSubprocessesAndExit(ProcessSignal signal) {
+  for (final process in _allProcesses) {
+    process.kill(signal);
+  }
+  exit(1);
+}
+
+void _watchExitSignal(ProcessSignal signal) {
+  signal.watch().listen(_killSubprocessesAndExit);
+}
+
+Future<Map<String, dynamic>> getTestCoverage(String packagRootDirectory) async {
+  _watchExitSignal(ProcessSignal.sighup);
+  _watchExitSignal(ProcessSignal.sigint);
+  if (!Platform.isWindows) {
+    _watchExitSignal(ProcessSignal.sigterm);
+  }
+
+  final serviceUriCompleter = Completer<Uri>();
+
+  final testProcess = _dartRun(
+    [
+      'run',
+      '--pause-isolates-on-exit',
+      '--disable-service-auth-codes',
+      '--enable-vm-service=0',
+      'test',
+    ],
+    onStdout: (line) {
+      if (!serviceUriCompleter.isCompleted) {
+        final uri = _extractVMServiceUri(line);
+        if (uri != null) {
+          serviceUriCompleter.complete(uri);
+        }
+      }
+    },
+    onStderr: (line) {
+      if (!serviceUriCompleter.isCompleted) {
+        if (line.contains('Could not start the VM service')) {
+          _killSubprocessesAndExit(ProcessSignal.sigkill);
+        }
+      }
+    },
+    workingDirectory: packagRootDirectory,
+  );
+
+  final serviceUri = await serviceUriCompleter.future;
+
+  // TODO: need to extract the scope output from the pubsec.yaml file
+  final Set<String> scopes = {};
+  Map<String, dynamic>? coverage;
+  await Chain.capture(
+    () async {
+      print("Collecting coverage from $packagRootDirectory");
+      coverage = await collect(
+        serviceUri,
+        true,
+        true,
+        false,
+        scopes,
+        functionCoverage: true,
+      );
+      print(json.encode(coverage));
+    },
+    onError: (dynamic error, Chain chain) {
+      stderr.writeln(error);
+      stderr.writeln(chain.terse);
+      // See http://www.retro11.de/ouxr/211bsd/usr/include/sysexits.h.html
+      // EX_SOFTWARE
+      exit(70);
+    },
+  );
+  await testProcess;
+  return coverage!;
+}
+
+Future<void> _dartRun(
+  List<String> args, {
+  required void Function(String) onStdout,
+  required void Function(String) onStderr,
+  required String workingDirectory,
+}) async {
+  final process = await Process.start(
+    Platform.executable,
+    args,
+    workingDirectory: workingDirectory,
+  );
+  _allProcesses.add(process);
+
+  void listen(
+    Stream<List<int>> stream,
+    IOSink sink,
+    void Function(String) onLine,
+  ) {
+    final broadStream = stream.asBroadcastStream();
+    broadStream.listen(sink.add);
+    broadStream.lines().listen(onLine);
+  }
+
+  listen(process.stdout, stdout, onStdout);
+  listen(process.stderr, stderr, onStderr);
+
+  final result = await process.exitCode;
+  if (result != 0) {
+    throw ProcessException(Platform.executable, args, '', result);
+  }
+}
+
+Uri? _extractVMServiceUri(String str) {
+  final listeningMessageRegExp = RegExp(
+    r'(?:Observatory|The Dart VM service is) listening on ((http|//)[a-zA-Z0-9:/=_\-\.\[\]]+)',
+  );
+  final match = listeningMessageRegExp.firstMatch(str);
+  if (match != null) {
+    return Uri.parse(match[1]!);
+  }
+  return null;
+}
+
+extension StandardOutExtension on Stream<List<int>> {
+  Stream<String> lines() =>
+      transform(const SystemEncoding().decoder).transform(const LineSplitter());
+}

--- a/lib/src/coverage/util.dart
+++ b/lib/src/coverage/util.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:path/path.dart' as path;
@@ -21,4 +22,20 @@ YamlMap _loadPubspec(String packageRoot) {
   final pubspecPath = getPubspecPath(packageRoot);
   final yaml = File(pubspecPath).readAsStringSync();
   return loadYaml(yaml, sourceUrl: Uri.file(pubspecPath)) as YamlMap;
+}
+
+Uri? extractVMServiceUri(String str) {
+  final listeningMessageRegExp = RegExp(
+    r'(?:Observatory|The Dart VM service is) listening on ((http|//)[a-zA-Z0-9:/=_\-\.\[\]]+)',
+  );
+  final match = listeningMessageRegExp.firstMatch(str);
+  if (match != null) {
+    return Uri.parse(match[1]!);
+  }
+  return null;
+}
+
+extension StandardOutExtension on Stream<List<int>> {
+  Stream<String> lines() =>
+      transform(const SystemEncoding().decoder).transform(const LineSplitter());
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,8 +8,10 @@ environment:
 
 # Add regular dependencies here.
 dependencies:
+  coverage: ^1.14.0
   google_generative_ai: ^0.4.6
   path: ^1.9.1
+  stack_trace: ^1.12.1
 
 dev_dependencies:
   lints: ^5.0.0


### PR DESCRIPTION
- Closes #1

## This PR integrates the `coverage` package to enable automated collection of code coverage data when running Dart tests.

---

### 🔧 Key Changes

- Implemented `runTestsAndCollectCoverage` to launch tests with VM service and coverage flags.
- Waits for the Dart VM service URI and collects merged coverage data from all isolates.
- Supports **branch** and **function** coverage collection via flags.
- Allows scoping of coverage output to specific package paths.
- Handles process signals to ensure subprocesses are terminated cleanly.

---

### 📊 Sample Output (Coverage Data)

```json
{
  "source": "package:math/src/trig_operations/trig.dart",
  "script": {
    "type": "@Script",
    "fixedId": true,
    "id": "libraries/1/scripts/package%3Amath%2Fsrc%2Ftrig_operations%2Ftrig.dart",
    "uri": "package:math/src/trig_operations/trig.dart",
    "_kind": "library"
  },
  "hits": [3, 1, 4, 1, 7, 1, 8, 1, 11, 1, 12, 1]
}
