### PR TITLE
 Add Benchmarking Framework for Testgen Performance Evaluation

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -19,9 +19,9 @@ include: package:lints/recommended.yaml
 #   rules:
 #     - camel_case_types
 
-# analyzer:
-#   exclude:
-#     - path/to/excluded/files/**
+analyzer:
+  exclude:
+    - benchmark/data/**
 
 # For more information about the core and recommended set of lints, see
 # https://dart.dev/go/core-lints

--- a/benchmark/data/.gitignore
+++ b/benchmark/data/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/benchmark/results/.gitignore
+++ b/benchmark/results/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/benchmark/run_benchmark.dart
+++ b/benchmark/run_benchmark.dart
@@ -212,7 +212,7 @@ void main() async {
       packagePath,
       scopeOutput: {packageName},
     );
-    final coverageByFile = formatCoverage(coverage);
+    final coverageByFile = await formatCoverage(coverage, packagePath);
 
     final declarations = await extractDeclarations(packagePath, packageName);
     final declarationsByFile = <String, List<Declaration>>{};

--- a/benchmark/run_benchmark.dart
+++ b/benchmark/run_benchmark.dart
@@ -1,1 +1,155 @@
-void main() {}
+import 'dart:io';
+import 'dart:math';
+
+import 'package:benchmark_harness/benchmark_harness.dart';
+import 'package:google_generative_ai/google_generative_ai.dart';
+import 'package:testgen/src/LLM/context_generator.dart';
+import 'package:testgen/src/LLM/llm.dart';
+import 'package:testgen/src/analyzer/declaration.dart';
+import 'package:testgen/src/analyzer/extractor.dart';
+import 'package:testgen/src/coverage/coverage_collection.dart';
+import 'package:path/path.dart' as path;
+
+class TestGenBenchmark extends AsyncBenchmarkBase {
+  final String packagePath;
+  final GenerativeModel model;
+  final int contextDepth;
+  final bool effectiveTestsOnly;
+  final Map<String, List<Declaration>> declarationsByFile;
+  final List<(Declaration declaration, List<int> lines)> declarationsToProcess;
+
+  TestGenBenchmark(
+    super.name, {
+    required this.packagePath,
+    required this.model,
+    required this.contextDepth,
+    required this.effectiveTestsOnly,
+    required this.declarationsByFile,
+    required this.declarationsToProcess,
+  });
+
+  @override
+  Future<void> run() async {
+    for (final (declaration, lines) in declarationsToProcess) {
+      final toBeTestedCode = formatUntestedCode(declaration, lines);
+      final contextMap = generateContextForDeclaration(
+        declaration,
+        maxDepth: contextDepth,
+      );
+      final contextCode = formatContext(contextMap);
+
+      final (status, chat, testFileManager) = await generateTestFile(
+        model,
+        toBeTestedCode,
+        contextCode,
+        packagePath,
+        '${declaration.name}_${declaration.id}_test.dart',
+      );
+
+      if (status == TestStatus.created) {
+        if (effectiveTestsOnly) {
+          final isImproved = await validateTestCoverageImprovement(
+            packagePath,
+            declaration,
+            lines.length,
+            scopeOutput: {path.basename(packagePath)},
+            declarationsByFile: declarationsByFile,
+          );
+          if (isImproved) {
+            print('✅ Test improved coverage for ${declaration.name}.');
+          } else {
+            print(
+              '❌ Test did not improve coverage for ${declaration.name}. '
+              'Deleting test file.',
+            );
+            testFileManager.deleteTest();
+          }
+        } else {
+          print('✅ Test generated for ${declaration.name}.');
+        }
+      }
+    }
+  }
+
+  @override
+  Future<void> teardown() async {
+    final testDir = Directory('$packagePath/test/testgen');
+    if (await testDir.exists()) {
+      await for (final entity in testDir.list()) {
+        if (entity is File && entity.path.contains('_test.dart')) {
+          await entity.delete();
+        }
+      }
+    }
+  }
+}
+
+void main() async {
+  final apiKey = Platform.environment['GEMINI_API_KEY'] ?? '';
+  final models = [
+    'gemini-2.5-pro',
+    'gemini-2.5-flash',
+    'gemini-2.5-flash-lite',
+  ];
+  final contextDepths = [0, 1, 2, 4, 8, 16];
+
+  // Assume this script is run from the root of the project
+  final benchmarkDataDir = Directory(
+    path.join(Directory.current.path, 'benchmark', 'data'),
+  );
+  final availablePackagePaths =
+      benchmarkDataDir
+          .listSync()
+          .whereType<Directory>()
+          .map((dir) => dir.absolute.path)
+          .toList();
+
+  for (final model in models) {
+    for (final contextDepth in contextDepths) {
+      for (final packagePath in availablePackagePaths) {
+        final packageName = path.basename(packagePath);
+        final coverage = await runTestsAndCollectCoverage(
+          packagePath,
+          scopeOutput: {packageName},
+        );
+        final coverageByFile = formatCoverage(coverage);
+
+        final declarations = await extractDeclarations(
+          packagePath,
+          packageName,
+        );
+        final declarationsByFile = <String, List<Declaration>>{};
+        for (final declaration in declarations) {
+          declarationsByFile
+              .putIfAbsent(declaration.path, () => [])
+              .add(declaration);
+        }
+
+        final untestedDeclarations = extractUntestedDeclarations(
+          declarationsByFile,
+          coverageByFile,
+        );
+        final declarationsToProcess =
+            (untestedDeclarations..shuffle(Random(42))).take(1).toList();
+
+        await Process.run('dart', [
+          'pub',
+          'add',
+          'test',
+        ], workingDirectory: packagePath);
+
+        await TestGenBenchmark(
+          'TestGen-$packageName - $model - ctx$contextDepth',
+          packagePath: packagePath,
+          model: createModel(model: model, apiKey: apiKey),
+          effectiveTestsOnly: false,
+          contextDepth: contextDepth,
+          declarationsByFile: declarationsByFile,
+          declarationsToProcess: declarationsToProcess,
+        ).report();
+
+        await Future.delayed(const Duration(seconds: 60));
+      }
+    }
+  }
+}

--- a/benchmark/run_benchmark.dart
+++ b/benchmark/run_benchmark.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 import 'dart:math';
 
@@ -10,6 +11,105 @@ import 'package:testgen/src/analyzer/extractor.dart';
 import 'package:testgen/src/coverage/coverage_collection.dart';
 import 'package:path/path.dart' as path;
 
+final benchmarkResults = BenchmarkResultsCollector();
+
+class BenchmarkResult {
+  final String testName;
+  final double executionTime;
+  final int successfulTests;
+  final int failedTests;
+  final int skippedTests;
+
+  BenchmarkResult({
+    required this.testName,
+    required this.executionTime,
+    required this.successfulTests,
+    required this.failedTests,
+    required this.skippedTests,
+  });
+
+  int get totalTests => successfulTests + failedTests + skippedTests;
+  double get successRate => totalTests > 0 ? successfulTests / totalTests : 0.0;
+
+  Map<String, dynamic> toJson() => {
+    'testName': testName,
+    'executionTime': executionTime,
+    'successfulTests': successfulTests,
+    'failedTests': failedTests,
+    'skippedTests': skippedTests,
+    'totalTests': totalTests,
+    'successRate': successRate,
+  };
+}
+
+class BenchmarkResultsCollector {
+  final List<BenchmarkResult> _results = [];
+
+  void addResult(BenchmarkResult result) {
+    _results.add(result);
+  }
+
+  List<BenchmarkResult> get results => List.unmodifiable(_results);
+
+  // Save all results to JSON file
+  Future<void> saveToFile(String filename) async {
+    final resultsData = {
+      'metadata': {
+        'generatedAt': DateTime.now().toIso8601String(),
+        'totalRuns': _results.length,
+      },
+      'results': _results.map((r) => r.toJson()).toList(),
+    };
+
+    final file = File(
+      path.join(Directory.current.path, 'benchmark', 'results', filename),
+    );
+    await file.parent.create(recursive: true);
+    await file.writeAsString(JsonEncoder.withIndent('  ').convert(resultsData));
+  }
+
+  void printSummary() {
+    if (_results.isEmpty) {
+      print('No benchmark results to summarize.');
+      return;
+    }
+
+    final totalTime = _results
+        .map((r) => r.executionTime)
+        .reduce((a, b) => a + b);
+    final avgTime = totalTime / _results.length;
+    final totalSuccessful = _results
+        .map((r) => r.successfulTests)
+        .reduce((a, b) => a + b);
+    final totalFailed = _results
+        .map((r) => r.failedTests)
+        .reduce((a, b) => a + b);
+    final totalSkipped = _results
+        .map((r) => r.skippedTests)
+        .reduce((a, b) => a + b);
+    final overallSuccessRate =
+        (totalSuccessful + totalFailed + totalSkipped) > 0
+            ? totalSuccessful / (totalSuccessful + totalFailed + totalSkipped)
+            : 0.0;
+
+    print('\n${'=' * 60}');
+    print('BENCHMARK SUMMARY');
+    print('=' * 60);
+    print('Total benchmark runs: ${_results.length}');
+    print('Average execution time: ${avgTime.toStringAsFixed(2)}ms');
+    print(
+      'Total tests generated: ${totalSuccessful + totalFailed}',
+    );
+    print('Successful tests: $totalSuccessful');
+    print('Failed tests: $totalFailed');
+    print('Skipped tests: $totalSkipped');
+    print(
+      'Overall success rate: ${(overallSuccessRate * 100).toStringAsFixed(1)}%',
+    );
+    print('=' * 60);
+  }
+}
+
 class TestGenBenchmark extends AsyncBenchmarkBase {
   final String packagePath;
   final GenerativeModel model;
@@ -17,6 +117,10 @@ class TestGenBenchmark extends AsyncBenchmarkBase {
   final bool effectiveTestsOnly;
   final Map<String, List<Declaration>> declarationsByFile;
   final List<(Declaration declaration, List<int> lines)> declarationsToProcess;
+
+  int failedTests = 0;
+  int successfulTests = 0;
+  int skippedTests = 0;
 
   TestGenBenchmark(
     super.name, {
@@ -47,6 +151,7 @@ class TestGenBenchmark extends AsyncBenchmarkBase {
       );
 
       if (status == TestStatus.created) {
+        successfulTests++;
         if (effectiveTestsOnly) {
           final isImproved = await validateTestCoverageImprovement(
             packagePath,
@@ -68,6 +173,7 @@ class TestGenBenchmark extends AsyncBenchmarkBase {
           print('✅ Test generated for ${declaration.name}.');
         }
       }
+      status == TestStatus.skipped ? skippedTests++ : failedTests++;
     }
   }
 
@@ -81,6 +187,19 @@ class TestGenBenchmark extends AsyncBenchmarkBase {
         }
       }
     }
+  }
+
+  @override
+  Future<void> report() async {
+    double time = await measure();
+    final result = BenchmarkResult(
+      testName: name,
+      executionTime: time,
+      successfulTests: successfulTests,
+      failedTests: failedTests,
+      skippedTests: skippedTests,
+    );
+    benchmarkResults.addResult(result);
   }
 }
 
@@ -152,4 +271,8 @@ void main() async {
       }
     }
   }
+  await benchmarkResults.saveToFile('results.json');
+  benchmarkResults.printSummary();
+
+  exit(0);
 }

--- a/benchmark/run_benchmark.dart
+++ b/benchmark/run_benchmark.dart
@@ -227,7 +227,7 @@ void main() async {
       coverageByFile,
     );
     final declarationsToProcess =
-        (untestedDeclarations..shuffle(Random(32)))
+        (untestedDeclarations..shuffle(Random()))
             .take(maxDeclarationsToProcess)
             .toList();
 

--- a/bin/testgen.dart
+++ b/bin/testgen.dart
@@ -161,7 +161,7 @@ Future<void> main(List<String> arguments) async {
     functionCoverage: flags.functionCoverage,
     scopeOutput: flags.scopeOutput,
   );
-  final coverageByFile = formatCoverage(coverage);
+  final coverageByFile = await formatCoverage(coverage, flags.package);
 
   final declarations = await extractDeclarations(
     flags.package,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   analyzer: ^7.4.5
   args: ^2.7.0
-  coverage: ^1.14.0
+  coverage: ^1.15.0
   google_generative_ai: ^0.4.7
   package_config: ^2.2.0
   path: ^1.9.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,5 +19,6 @@ dependencies:
 
 
 dev_dependencies:
+  benchmark_harness: ^2.3.1
   lints: ^5.0.0
   test: ^1.24.0


### PR DESCRIPTION
### Overview
This PR introduces a benchmarking framework to evaluate testgen's performance across different **LLM models, context depths, and package configurations.** The framework provides detailed metrics collection including execution time, success rates, and token usage statistics.
- closes #20 

---

### Implementation Details

#### 1. Benchmarking Structure
Built the benchmarking using `package:benchmark_harness` with custom extensions:
- **TestGenBenchmark class** - Extends `AsyncBenchmarkBase` for systematic performance testing
- **BenchmarkResult class** - Encapsulates all metrics including execution time, test counts, and token statistics
- **BenchmarkResultsCollector** - Global collector for aggregating and exporting results

---

#### 2. Multi-Configuration Testing Support
Implemented configurable benchmarking across multiple dimensions:
- **Model variations** - Supports gemini-2.5-pro, gemini-2.5-flash, and gemini-2.5-flash-lite
- **Context depth testing** - Configurable context depths (0, 1, 2, 4, 8, 16) to measure impact on performance
- **Package-specific analysis** - Automatic discovery and testing of packages in `benchmark/data/` directory

---

### Usage
```bash
# Set API key and run benchmarks
export GEMINI_API_KEY="your_api_key"
dart run benchmark/run_benchmark.dart
```
---

### Results Example
```json
{
  "metadata": {
    "generatedAt": "2025-08-20T01:15:35.407371",
    "totalRuns": 2
  },
  "results": [
    {
      "testName": "pkg:fftea|model:gemini-2.5-flash|ctx:0",
      "totalDeclarationsInTest": 5,
      "executionTimeInSecs": 21.213368,
      "successRate": 0.2,
      "successfulTests": 1,
      "failedTests": 0,
      "skippedTests": 4,
      "averageTokenCount": 592.8,
      "minTokenCount": 476,
      "maxTokenCount": 947,
      "p90TokenCount": 947
    },
    {
      "testName": "pkg:fftea|model:gemini-2.5-flash|ctx:4",
      "totalDeclarationsInTest": 5,
      "executionTimeInSecs": 88.692155,
      "successRate": 0.6,
      "successfulTests": 3,
      "failedTests": 0,
      "skippedTests": 2,
      "averageTokenCount": 1516.4,
      "minTokenCount": 491,
      "maxTokenCount": 2505,
      "p90TokenCount": 2505
    }
  ]
}


