### PR TITLE
Use HitMap.parseJson during formatting

### DIFF
--- a/bin/testgen.dart
+++ b/bin/testgen.dart
@@ -161,7 +161,7 @@ Future<void> main(List<String> arguments) async {
     functionCoverage: flags.functionCoverage,
     scopeOutput: flags.scopeOutput,
   );
-  final coverageByFile = formatCoverage(coverage);
+  final coverageByFile = await formatCoverage(coverage, flags.package);
 
   final declarations = await extractDeclarations(
     flags.package,


### PR DESCRIPTION
The coverage data returned by package:coverage's `collect` function is in a weird format. The best way to get it into a more useful format is to use `HitMap.parseJson`. In future, package:coverage will just return the `HitMap`s directly.