### PR TITLE
Recompute untested declarations after each generated test

### DIFF
--- a/bin/testgen.dart
+++ b/bin/testgen.dart
@@ -247,7 +247,6 @@ Future<void> main(List<String> arguments) async {
   }
 
   final skippedOrFailedDeclarations = HashSet<int>();
-  final file = File(path.join(flags.package, 'prompt.log'));
 
   while (untestedDeclarations.isNotEmpty) {
     final idx = untestedDeclarations.indexWhere(
@@ -260,12 +259,7 @@ Future<void> main(List<String> arguments) async {
     final (declaration, lines) = untestedDeclarations[idx];
     print(
       '[testgen] Generating tests for ${declaration.name}, remaining: '
-      '${untestedDeclarations.length - skippedOrFailedDeclarations.length}',
-    );
-    await file.writeAsString(
-      '[testgen] Generating tests for ${declaration.name}, remaining: '
-      '${untestedDeclarations.length - skippedOrFailedDeclarations.length}\n',
-      mode: FileMode.append,
+      '${untestedDeclarations.length - skippedOrFailedDeclarations.length - 1}',
     );
 
     final toBeTestedCode = formatUntestedCode(declaration, lines);


### PR DESCRIPTION
This PR updates the test generation workflow to dynamically **recompute the list of untested declarations after each successfully generated test.**

- closes #38

Previously, untested declarations were determined once at startup and processed in order. But generating a test for a declaration can also cover lines from other declarations, making parts of the original queue outdated (**will not increase the coverage**) . By recalculating untested declarations after each test, we eliminate redundant work, keep the queue in sync with real coverage, and significantly reduce the overall runtime.

### Results From Real Packages

I tried this change on multiple real Dart packages.
Below are snippets from the actual remaining-count logs, demonstrating that the updated workflow decreases the work queue based on live coverage, with no redundant regeneration.

#### fftea
```dart
[testgen] Generating tests for circularConvolution, remaining: 96
[testgen] Generating tests for convolution, remaining: 78
[testgen] Generating tests for resample, remaining: 74
[testgen] Generating tests for resampleByRatio, remaining: 67
[testgen] Generating tests for resampleByRate, remaining: 66
[testgen] Generating tests for inPlaceApplyWindow, remaining: 44
[testgen] Generating tests for applyWindow, remaining: 43
[testgen] Generating tests for _makeFFT, remaining: 42
[testgen] Generating tests for inPlaceApplyWindowReal, remaining: 41
[testgen] Generating tests for applyWindowReal, remaining: 40
[testgen] Generating tests for _makeWindow, remaining: 39
[testgen] Generating tests for cosine, remaining: 38
[testgen] Generating tests for hanning, remaining: 37
[testgen] Generating tests for hamming, remaining: 34
[testgen] Generating tests for bartlett, remaining: 33
[testgen] Generating tests for blackman, remaining: 32
[testgen] Generating tests for STFT, remaining: 31
[testgen] Generating tests for size, remaining: 30
[testgen] Generating tests for frequency, remaining: 29
[testgen] Generating tests for inPlaceFft, remaining: 26
[testgen] Generating tests for indexOfFrequency, remaining: 25
[testgen] Generating tests for indexOfFrequency, remaining: 24
[testgen] Generating tests for run, remaining: 23
[testgen] Generating tests for stream, remaining: 20
[testgen] Generating tests for runAndCopy, remaining: 18
[testgen] Generating tests for toRealArray, remaining: 17
[testgen] Generating tests for _calculateTwiddles, remaining: 16
[testgen] Generating tests for toString, remaining: 15
[testgen] Generating tests for _stridedFft, remaining: 14
[testgen] Generating tests for toString, remaining: 13

```

#### stack_trace
```dart
[testgen] Generating tests for _terseRegExp, remaining: 105
[testgen] Generating tests for _v8Trace, remaining: 104
[testgen] Generating tests for _v8TraceLine, remaining: 103
[testgen] Generating tests for _firefoxEvalTrace, remaining: 102
[testgen] Generating tests for _firefoxSafariTrace, remaining: 101
[testgen] Generating tests for _friendlyTrace, remaining: 100
[testgen] Generating tests for format, remaining: 99
[testgen] Generating tests for Trace.current, remaining: 77
[testgen] Generating tests for Trace.parse, remaining: 74
[testgen] Generating tests for _parseVM, remaining: 73
[testgen] Generating tests for Trace.parseV8, remaining: 72
[testgen] Generating tests for Trace.parseJSCore, remaining: 63
[testgen] Generating tests for Trace.parseIE, remaining: 62
[testgen] Generating tests for Trace.parseFirefox, remaining: 61
[testgen] Generating tests for Trace.parseSafari, remaining: 54
[testgen] Generating tests for Trace.parseSafari6_1, remaining: 53
[testgen] Generating tests for Trace.parseSafari6_0, remaining: 52
[testgen] Generating tests for Trace.parseFriendly, remaining: 51
[testgen] Generating tests for vmTrace, remaining: 50
[testgen] Generating tests for foldFrames, remaining: 49

```

#### glob
```dart
[testgen] Generating tests for _quoteRegExp, remaining: 98
[testgen] Generating tests for caseSensitive, remaining: 97
[testgen] Generating tests for _contextIsAbsolute, remaining: 96
[testgen] Generating tests for quote, remaining: 95
[testgen] Generating tests for Glob, remaining: 94
[testgen] Generating tests for listFileSystem, remaining: 89
[testgen] Generating tests for listFileSystemSync, remaining: 78
[testgen] Generating tests for matchAsPrefix, remaining: 77
[testgen] Generating tests for allMatches, remaining: 73
[testgen] Generating tests for _listTreeForFileSystem, remaining: 72
```

These numbers will naturally vary depending on the rate and quality of the generated tests.