### PR TITLE
fix(api): exit early when API key is invalid (#53)

### DIFF
--- a/lib/src/LLM/test_generator.dart
+++ b/lib/src/LLM/test_generator.dart
@@ -190,6 +190,14 @@ class TestGenerator {
           continue;
         }
 
+        if (errorMessage.contains('api key not valid')) {
+          status = TestStatus.failed;
+          await testFile.deleteTest();
+          throw StateError(
+            'Invalid API key provided. Please pass a valid API key.',
+          );
+        }
+
         _logger.warning('Error encountered: $errorMessage');
         prompt = promptGenerator.fixError(errorMessage);
       }

--- a/lib/src/LLM/test_generator.dart
+++ b/lib/src/LLM/test_generator.dart
@@ -191,11 +191,7 @@ class TestGenerator {
         }
 
         if (errorMessage.contains('api key not valid')) {
-          status = TestStatus.failed;
-          await testFile.deleteTest();
-          throw StateError(
-            'Invalid API key provided. Please pass a valid API key.',
-          );
+          rethrow;
         }
 
         _logger.warning('Error encountered: $errorMessage');

--- a/test/LLM/test_generator_test.dart
+++ b/test/LLM/test_generator_test.dart
@@ -334,9 +334,7 @@ void main() {
     });
 
     test('Exit immediately when API key is invalid', () async {
-      when(
-        mockChat.sendMessage(any),
-      ).thenAnswer(
+      when(mockChat.sendMessage(any)).thenAnswer(
         (_) async =>
             throw Exception('api key not valid. please pass a valid api key.'),
       );

--- a/test/LLM/test_generator_test.dart
+++ b/test/LLM/test_generator_test.dart
@@ -333,6 +333,24 @@ void main() {
       );
     });
 
+    test('Exit immediately when API key is invalid', () async {
+      when(
+        mockChat.sendMessage(any),
+      ).thenAnswer(
+        (_) async =>
+            throw Exception('api key not valid. please pass a valid api key.'),
+      );
+
+      expect(
+        () async => await generator.generate(
+          toBeTestedCode: '',
+          contextCode: '',
+          fileName: 'tmp_file.dart',
+        ),
+        throwsA(isA<StateError>()),
+      );
+    });
+
     test('Handle non-rate-limit errors (network, parsing, ...)', () async {
       when(
         mockAnalysisValidator.validate(any, any),

--- a/test/LLM/test_generator_test.dart
+++ b/test/LLM/test_generator_test.dart
@@ -347,7 +347,7 @@ void main() {
           contextCode: '',
           fileName: 'tmp_file.dart',
         ),
-        throwsA(isA<StateError>()),
+        throwsA(isA<Exception>()),
       );
     });
 


### PR DESCRIPTION
- Fixes #53 
## Summary of changes

- **Early Exit on Invalid API Key:**  
  Updated `TestGenerator` to immediately stop execution and throw a `StateError` when an `"api key not valid"` error is returned from the LLM, preventing unnecessary retries

- **Test Coverage:**  
  Added a unit test in `test_generator_test.dart` to verify that the generator exits correctly when an invalid API key is encountered
