### PR TITLE
delete coverage_import_test.dart after the execution

### DIFF
--- a/bin/testgen.dart
+++ b/bin/testgen.dart
@@ -355,22 +355,17 @@ Future<void> main(List<String> arguments) async {
   await testGenerator.dispose();
 
   // For deleting generated coverage_import_test file
-  final coverageFilePath = path.join(
-    flags.package, 
-    'test', 
-    'testgen', 
-    'coverage_import_test.dart'
+  final coverageFile = File(
+    path.joinAll([flags.package, ...coverageImportFilePath]),
   );
 
-  final coverageFile = File(coverageFilePath);
-
-    if (await coverageFile.exists()) {
-      try {
-        await coverageFile.delete();
-        _logger.info('Coverage file deleted successfully');
-      } catch (e) {
-        _logger.warning('Failed to delete the coverage file: $e');
-      }
+  if (await coverageFile.exists()) {
+    try {
+      await coverageFile.delete();
+      _logger.info('Coverage file deleted successfully');
+    } catch (e) {
+      _logger.warning('Failed to delete the coverage file: $e');
     }
+  }
   exit(0);
 }

--- a/bin/testgen.dart
+++ b/bin/testgen.dart
@@ -353,5 +353,24 @@ Future<void> main(List<String> arguments) async {
   }
 
   await testGenerator.dispose();
+
+  // For deleting generated coverage_import_test file
+  final coverageFilePath = path.join(
+    flags.package, 
+    'test', 
+    'testgen', 
+    'coverage_import_test.dart'
+  );
+
+  final coverageFile = File(coverageFilePath);
+
+    if (await coverageFile.exists()) {
+      try {
+        await coverageFile.delete();
+        _logger.info('Coverage file deleted successfully');
+      } catch (e) {
+        _logger.warning('Failed to delete the coverage file: $e');
+      }
+    }
   exit(0);
 }


### PR DESCRIPTION
### **Problem**

The `test/testgen/coverage_import_test.dart` file is created during execution for coverage collection, but it causes analyzer warnings (unused imports) 

### **Solution**
Delete the file at the end of execution in `bin/testgen.dart.`

**Changes**
Added a code before `exit(0)` to delete the temporary coverage file
Includes error handling and logging

### Fixes #55

### **This after i made a Script file to test it and it Successfully deleted** 🎉🎉

<img width="1366" height="725" alt="image" src="https://github.com/user-attachments/assets/d1d6adff-c73b-4975-a0a6-d24039c3f79c" />

