### PR TITLE
feat: Add requiredDependencies to LLM schema to detect missing packages

### DIFF
--- a/lib/src/LLM/model.dart
+++ b/lib/src/LLM/model.dart
@@ -60,6 +60,12 @@ class GeminiModel {
               'that do not make sense to test.',
           nullable: false,
         ),
+        'requiredDependencies': Schema.array(
+          description:
+              'List of package dependencies required by the generated test code (e.g., ["mockito", "build_runner"]).',
+          items: Schema.string(),
+          nullable: true,
+        ),
       },
       requiredProperties: ['code', 'needTesting'],
     );
@@ -118,10 +124,15 @@ class GeminiChat {
 /// Contains the generated Dart test [code] and a boolean [needTesting] that
 /// indicates whether the model determined the input actually requires tests.
 class ChatResponse {
-  ChatResponse({required this.code, required this.needTesting});
+  ChatResponse({
+    required this.code,
+    required this.needTesting,
+    this.requiredDependencies = const [],
+  });
 
   final String code;
   final bool needTesting;
+  final List<String> requiredDependencies;
 
   /// Parses a JSON text response from the model into a [ChatResponse].
   ///
@@ -137,9 +148,12 @@ class ChatResponse {
     try {
       final json = jsonDecode(response.text!) as Map<String, dynamic>;
 
+      final deps = json['requiredDependencies'] as List<dynamic>?;
+
       return ChatResponse(
         code: json['code'] as String,
         needTesting: json['needTesting'] as bool,
+        requiredDependencies: deps?.map((e) => e.toString()).toList() ?? [],
       );
     } catch (e) {
       throw FormatException(


### PR DESCRIPTION
Closes #50
### Description
Some generated tests may import third-party packages that are not listed in the project's `pubspec.yaml`. This results in analyzer warnings (when the package is a transitive dependency) or outright compilation errors, causing the generated test file to be ignored.
To solve this, I've updated the `Schema.object` properties sent to the Gemini model to explicitly ask the LLM to return an array of `requiredDependencies`. 
This enables `flutter_testgen` to programmatically detect missing dependencies (e.g., `mockito`, `http`, `build_runner`) and add them explicitly.

### Changes Made
- Added `requiredDependencies` as a `Schema.array` of strings in `_createModel` (inside `lib/src/LLM/model.dart`).
- Updated the `ChatResponse` class and its `fromText` factory to parse the `requiredDependencies` field from the model's JSON response, defaulting to an empty list.

### Verification
I created a test script forcing the LLM to write a test for an HTTP-based service using Mockito. As seen in the screenshot below, the LLM successfully populates the `requiredDependencies` field with `[http, mockito, build_runner]`.


